### PR TITLE
Fix missing argument in ApiResponse

### DIFF
--- a/rointesdk/rointe_api.py
+++ b/rointesdk/rointe_api.py
@@ -253,7 +253,7 @@ class RointeAPI:
 
         if not response:
             return ApiResponse(
-                False, "No response from API in get_installation_by_id()"
+                False, None, "No response from API in get_installation_by_id()"
             )
 
         if response.status_code != 200:


### PR DESCRIPTION
```
  File "/usr/local/lib/python3.11/site-packages/rointesdk/rointe_api.py", line 204, in get_installation_devices
    installation_response = self.get_installation_by_id(installation_id)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rointesdk/rointe_api.py", line 255, in get_installation_by_id
    return ApiResponse(
           ^^^^^^^^^^^^
TypeError: ApiResponse.__new__() missing 1 required positional argument: 'error_message'
```